### PR TITLE
Use -- rather than - for vivliostyles arguments

### DIFF
--- a/rocks.xml.pdf.css.page/build.xml
+++ b/rocks.xml.pdf.css.page/build.xml
@@ -145,8 +145,8 @@
 
         <exec executable="${html.pdf.formatter.path}">
             <arg line="${xhtml.file}"/>
-            <arg line="-output=${output.file}"/>
-            <arg line="-style=${css.file}"/>
+            <arg line="--output=${output.file}"/>
+            <arg line="--style=${css.file}"/>
         </exec>
     </target>
 


### PR DESCRIPTION
Vivliostyle uses -- not - for arguments. This code works under OS X on my machine.