### PR TITLE
Enable extension. Use plugin URL for base XHTML module

### DIFF
--- a/rocks.xml.pdf.css.page/build_template.xml
+++ b/rocks.xml.pdf.css.page/build_template.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project name="rocks.xml.pdf.css.page">
+
+    <property name="html.pdf.formatter" value="pdfreactor"/>
+
+    <property name="css.file"
+              value="${dita.plugin.rocks.xml.pdf.css.page.dir}${file.separator}css${file.separator}main.css"/>
+
+    <property name="index" value="true"/>
+
+    <property name="toc" value="true"/>
+
+
+    <import file="dita-merge.xml"/>
+
+    <condition property="use.vivliostyle">
+        <equals arg1="${html.pdf.formatter}" arg2="vivliostyle" casesensitive="false"/>
+    </condition>
+
+    <condition property="use.pdfreactor">
+        <equals arg1="${html.pdf.formatter}" arg2="pdfreactor" casesensitive="false"/>
+    </condition>
+
+    <target name="dita2pdf-css-page" depends="dita2pdf-css-page.init,
+                                              map2pdf-css-page.merged,
+                                              topic2pdf-css-page.init, map2pdf-css-page.init,
+                                              pdf-css-page.dita2html,
+                                              prepare.common.css,
+                                              run.pdfreactor, run.vivliostyle"/>
+
+    <target name="dita2pdf-css-page.init" depends="check.formatter, check.formatter.path,
+                                                   check.pdfreactor, check.vivliostyle,
+                                                   check.css.file"/>
+
+    <target name="check.formatter">
+        <fail message="Unsupported &quot;html.pdf.formatter&quot; is set. Valid options are: pdfreactor, vivliostyle.">
+            <condition>
+                <not>
+                    <or>
+                        <equals arg1="${html.pdf.formatter}" arg2="vivliostyle" casesensitive="false"/>
+                        <equals arg1="${html.pdf.formatter}" arg2="pdfreactor" casesensitive="false"/>
+                    </or>
+                </not>
+            </condition>
+        </fail>
+    </target>
+
+    <target name="check.formatter.path">
+        <fail message="Property &quot;html.pdf.formatter.path&quot; is not set. Please, set path to the PDF formatter.">
+            <condition>
+                <not>
+                    <isset property="html.pdf.formatter.path"/>
+                </not>
+            </condition>
+        </fail>
+    </target>
+
+    <target name="check.pdfreactor" if="${use.pdfreactor}">
+        <condition property="formatter.available">
+            <available file="${html.pdf.formatter.path}"/>
+        </condition>
+
+        <fail unless="formatter.available">
+            Cannot find PDFreactor: "${html.pdf.formatter.path}". It can be purchased at: http://www.pdfreactor.com/
+        </fail>
+    </target>
+
+    <target name="check.vivliostyle" if="${use.vivliostyle}">
+        <condition property="formatter.available">
+            <available file="${html.pdf.formatter.path}"/>
+        </condition>
+
+        <fail unless="formatter.available">
+            Cannot find Vivliostyle Formatter: "${html.pdf.formatter.path}". It can be purchased at: http://vivliostyle.com/
+        </fail>
+    </target>
+
+    <target name="check.css.file">
+        <condition property="input.css.file.available">
+            <available file="${css.file}"/>
+        </condition>
+
+        <fail unless="input.css.file.available">
+            Cannot find the CSS file: ${css.file}. Please check the file path.
+        </fail>
+    </target>
+
+    <target name="pdf-css-page.image.dir.init">
+        <property name="preprocess.copy-html.skip" value="yes"/>
+        <condition property="copy-image.todir" value="${dita.temp.dir}/${uplevels}" else="${output.dir}">
+            <equals arg1="${generate.copy.outer}" arg2="1"/>
+        </condition>
+        <copy todir="${dita.temp.dir}/${uplevels}">
+            <fileset dir="${user.input.dir}" includesfile="${dita.temp.dir}/${imagefile}" />
+        </copy>
+    </target>
+
+    <target name="topic2pdf-css-page.init" if="noMap">
+        <basename property="dita.topic.file.name" file="${args.input}"/>
+
+        <property name="dita.file" value="${dita.temp.dir}${file.separator}${dita.topic.file.name}"/>
+
+        <property name="xhtml.file" value="${dita.temp.dir}${file.separator}${dita.topic.filename.root}.xhtml"/>
+
+        <property name="output.file" value="${output.dir}${file.separator}${dita.topic.filename.root}.pdf"/>
+    </target>
+
+    <target name="map2pdf-css-page.init" unless="noMap">
+        <property name="dita.file" value="${dita.temp.dir}${file.separator}stage1a.xml"/>
+
+        <property name="xhtml.file" value="${dita.temp.dir}${file.separator}${dita.map.filename.root}.xhtml"/>
+
+        <property name="output.file" value="${output.dir}${file.separator}${dita.map.filename.root}.pdf"/>
+    </target>
+
+    <target name="pdf-css-page.dita2html">
+        <property name="xsl.file"
+                  value="${dita.plugin.rocks.xml.pdf.css.page.dir}${file.separator}xslt${file.separator}dita2pdf-css-page-import.xsl"/>
+
+        <condition property="generate.index" value="true()" else="false()">
+            <istrue value="${index}"/>
+        </condition>
+
+        <condition property="generate.toc" value="true()" else="false()">
+            <istrue value="${toc}"/>
+        </condition>
+
+        <xslt in="${dita.file}" out="${xhtml.file}" style="${xsl.file}">
+            <xmlcatalog refid="dita.catalog"/>
+            <param name="CSS" expression="${args.css.file}" if="args.css.file"/>
+            <param name="CSSPATH" expression="${user.csspath}" if="user.csspath"/>
+            <param name="generate-index" expression="${generate.index}" type="XPATH_BOOLEAN"/>
+            <param name="generate-toc" expression="${generate.toc}" type="XPATH_BOOLEAN"/>
+        </xslt>
+    </target>
+
+    <target name="prepare.common.css">
+        <property name="commonltr.css.file"
+                  value="${dita.plugin.rocks.xml.pdf.css.page.dir}${file.separator}css${file.separator}commonltr.css"/>
+        <copy file="${commonltr.css.file}" todir="${dita.temp.dir}"/>
+    </target>
+
+    <target name="run.vivliostyle" if="use.vivliostyle">
+        <echo message="[WARN]: You are using Vivliostyle. Please notice that TOC and Index may not work properly."/>
+
+        <exec executable="${html.pdf.formatter.path}">
+            <arg line="${xhtml.file}"/>
+            <arg line="--output=${output.file}"/>
+            <arg line="--style=${css.file}"/>
+        </exec>
+    </target>
+
+    <target name="run.pdfreactor" if="use.pdfreactor">
+        <java jar="${html.pdf.formatter.path}" fork="yes">
+            <arg line="-s ${css.file}"/>
+            <arg line="-a"/>
+            <arg line="${xhtml.file}"/>
+            <arg line="${output.file}"/>
+        </java>
+    </target>
+
+</project>

--- a/rocks.xml.pdf.css.page/build_template.xml
+++ b/rocks.xml.pdf.css.page/build_template.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<project name="rocks.xml.pdf.css.page">
+<project name="rocks.xml.pdf.css.page"
+  xmlns:dita="http://dita-ot.sourceforge.net"
+  >
 
     <property name="html.pdf.formatter" value="pdfreactor"/>
 
@@ -131,6 +133,7 @@
             <param name="CSSPATH" expression="${user.csspath}" if="user.csspath"/>
             <param name="generate-index" expression="${generate.index}" type="XPATH_BOOLEAN"/>
             <param name="generate-toc" expression="${generate.toc}" type="XPATH_BOOLEAN"/>
+            <dita:extension id="xsl.pdf-css-page.xslt.param" behavior="org.dita.dost.platform.InsertAction"/>
         </xslt>
     </target>
 
@@ -147,6 +150,7 @@
             <arg line="${xhtml.file}"/>
             <arg line="--output=${output.file}"/>
             <arg line="--style=${css.file}"/>
+            <dita:extension id="xsl.pdf-css-page.vivlio.param" behavior="org.dita.dost.platform.InsertAction"/>
         </exec>
     </target>
 
@@ -156,6 +160,7 @@
             <arg line="-a"/>
             <arg line="${xhtml.file}"/>
             <arg line="${output.file}"/>
+            <dita:extension id="xsl.pdf-css-page.pdfreactor.param" behavior="org.dita.dost.platform.InsertAction"/>
         </java>
     </target>
 

--- a/rocks.xml.pdf.css.page/plugin.xml
+++ b/rocks.xml.pdf.css.page/plugin.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin id="rocks.xml.pdf.css.page">
+    
+    <extension-point id="xsl.pdf-css-page" name="PDF CSS pagination"/>
+  
+    <template file="build_template.xml"/>
+    <template file="xslt/dita2pdf-css-page-import_template.xsl"/>
+  
     <feature extension="dita.conductor.transtype.check" value="pdf-css-page"/>
     <feature extension="dita.transtype.print" value="pdf-css-page"/>
     <feature extension="dita.conductor.target.relative" file="integrator.xml"/>

--- a/rocks.xml.pdf.css.page/plugin.xml
+++ b/rocks.xml.pdf.css.page/plugin.xml
@@ -2,6 +2,9 @@
 <plugin id="rocks.xml.pdf.css.page">
     
     <extension-point id="xsl.pdf-css-page" name="PDF CSS pagination"/>
+    <extension-point id="xsl.pdf-css-page.xslt.param" name="PDF CSS XSLT parameters"/>
+    <extension-point id="xsl.pdf-css-page.vivlio.param" name="Vivliostyle command parameters"/>
+    <extension-point id="xsl.pdf-css-page.pdfreactor.param" name="PDFreactor command parameters"/>
   
     <template file="build_template.xml"/>
     <template file="xslt/dita2pdf-css-page-import_template.xsl"/>

--- a/rocks.xml.pdf.css.page/xslt/dita2pdf-css-page-import_template.xsl
+++ b/rocks.xml.pdf.css.page/xslt/dita2pdf-css-page-import_template.xsl
@@ -3,7 +3,11 @@
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 exclude-result-prefixes="#all">
 
-    <xsl:import href="../../org.dita.xhtml/xsl/dita2xhtml.xsl"/>
+  <dita:extension id="xsl.pdf-css-page" 
+    behavior="org.dita.dost.platform.ImportXSLAction" 
+    xmlns:dita="http://dita-ot.sourceforge.net"/>
+  
+    <xsl:import href="plugin:org.dita.xhtml:xsl/dita2xhtml.xsl"/>
     <xsl:import href="dita2pdf-css-page-main.xsl"/>
     <xsl:import href="dita2pdf-css-page-toc.xsl"/>
     <xsl:import href="dita2pdf-css-page-index.xsl"/>

--- a/rocks.xml.pdf.css.page/xslt/dita2pdf-css-page-main.xsl
+++ b/rocks.xml.pdf.css.page/xslt/dita2pdf-css-page-main.xsl
@@ -5,6 +5,11 @@
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
                 exclude-result-prefixes="#all">
 
+  <dita:extension id="xsl.transtype-epub" 
+    behavior="org.dita.dost.platform.ImportXSLAction" 
+    xmlns:dita="http://dita-ot.sourceforge.net"/>
+  
+  
 
     <xsl:template match="*[contains(@class, ' map/map ')]">
         <xsl:apply-templates select="." mode="root_element"/>

--- a/rocks.xml.pdf.css.page/xslt/dita2pdf-css-page-main.xsl
+++ b/rocks.xml.pdf.css.page/xslt/dita2pdf-css-page-main.xsl
@@ -5,12 +5,6 @@
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
                 exclude-result-prefixes="#all">
 
-  <dita:extension id="xsl.transtype-epub" 
-    behavior="org.dita.dost.platform.ImportXSLAction" 
-    xmlns:dita="http://dita-ot.sourceforge.net"/>
-  
-  
-
     <xsl:template match="*[contains(@class, ' map/map ')]">
         <xsl:apply-templates select="." mode="root_element"/>
     </xsl:template>


### PR DESCRIPTION
Added extension points to make the plugin extensible. Also use the plugin URI for the base XHTML module rather than relative path (if the OT catalog is in your catalog list in Oyxgen it will resolve the URI reference when you're editing).

For completeness should also add a parameter extension point but I'm out of time for now.